### PR TITLE
Fix auth route imports

### DIFF
--- a/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/routes/auth.py
+++ b/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/routes/auth.py
@@ -13,8 +13,6 @@ import re
 
 from src.extensions import db, limiter, blacklisted_tokens
 from src.models.database import User, AuditLog
-from src.utils.validators import AuthValidator
-from src.utils.helpers import log_action, get_client_info
 
 auth_bp = Blueprint('auth', __name__)
 


### PR DESCRIPTION
## Summary
- remove invalid utils imports from `auth.py`

## Testing
- `python3 -m compileall Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/routes/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_6855c32f89508331bc463f4c54cf78cb