### PR TITLE
Fix regex string for email validation

### DIFF
--- a/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/models/database.py
+++ b/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/models/database.py
@@ -128,7 +128,7 @@ class User(TimestampMixin, db.Model):
             errors.append("Nome deve ter pelo menos 2 caracteres")
         
         # Validar email
-        email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}
+        email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
         if not self.email or not re.match(email_pattern, self.email):
             errors.append("Email inválido")
         


### PR DESCRIPTION
## Summary
- fix unclosed email regex string in `database.py`

## Testing
- `python -m py_compile Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/models/database.py`

------
https://chatgpt.com/codex/tasks/task_e_6855c5bad2bc8331a9600003ed2a30c8