### PR TITLE
Fix auth route imports and email regex

### DIFF
--- a/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/models/database.py
+++ b/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/models/database.py
@@ -128,7 +128,7 @@ class User(TimestampMixin, db.Model):
             errors.append("Nome deve ter pelo menos 2 caracteres")
         
         # Validar email
-        email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}
+        email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
         if not self.email or not re.match(email_pattern, self.email):
             errors.append("Email inválido")
         

--- a/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/routes/auth.py
+++ b/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/backend/src/routes/auth.py
@@ -13,8 +13,6 @@ import re
 
 from src.extensions import db, limiter, blacklisted_tokens
 from src.models.database import User, AuditLog
-from src.utils.validators import AuthValidator
-from src.utils.helpers import log_action, get_client_info
 
 auth_bp = Blueprint('auth', __name__)
 


### PR DESCRIPTION
## Summary
- remove invalid utils imports from `auth.py`
- correct email regex in `database.py` validation

## Testing
- `python3 -m compileall backend/src/routes/auth.py`
- `python3 -m py_compile backend/src/models/database.py`


------
https://chatgpt.com/codex/tasks/task_e_6855c32f89508331bc463f4c54cf78cb