### PR TITLE
Fix project list extraction

### DIFF
--- a/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/frontend/src/services/api.js
+++ b/Apollo-Project-Orchestrator-Local/Apollo-Project-Orchestrator-Local/frontend/src/services/api.js
@@ -114,7 +114,7 @@ export const ApiService = {
         return { error: data.message || 'Erro ao carregar projetos' };
       }
 
-      return { success: true, projects: data };
+      return { success: true, projects: data.projects };
     } catch (error) {
       console.error('Get projects error:', error);
       return { error: 'Erro de conexão com o servidor' };


### PR DESCRIPTION
## Summary
- fix `getProjects` to return projects array

## Testing
- `npm run lint` *(fails: `vite.config.js` no-undef)*
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6855f8948dd8833189a21b008da21556